### PR TITLE
[Simulator] Charts are empty in the screenshot

### DIFF
--- a/sample-kendoui-professional/scripts/gauge.js
+++ b/sample-kendoui-professional/scripts/gauge.js
@@ -34,6 +34,7 @@
             gauge = $gauge.kendoRadialGauge({
                 theme: global.app.chartsTheme,
                 renderAs: "svg",
+                transitions: false,
                 pointer: {
                     value: value
                 },

--- a/sample-kendoui-professional/scripts/pie-chart.js
+++ b/sample-kendoui-professional/scripts/pie-chart.js
@@ -21,6 +21,7 @@
             pieChart = $pieChart.kendoChart({
                 theme: global.app.chartsTheme,
                 renderAs: "svg",
+                transitions: false,
                 title: {
                     position: "top",
                     text: "Internet Population Growth, 2007 - 2012"

--- a/sample-kendoui-professional/scripts/stock-chart.js
+++ b/sample-kendoui-professional/scripts/stock-chart.js
@@ -25,6 +25,7 @@
             $stockChart.kendoStockChart({
                 theme: global.app.chartsTheme,
                 renderAs: "svg",
+                transitions: false,
                 dataSource: {
                     transport: {
                         read: {


### PR DESCRIPTION
This is due to the combination of 2 factors:
* We resize the browser in order to take a screenshot with the real device size
* The sample redraws the charts on window resize (e.g.: pie-chart.js, ln 73)
As a result the screenshot is taken before the chart is rendered completely.

As a workaround we minimize the time for the chart redraw by disabling all transitions in it.
NB: The problem persists in stock-chart.js for some reason (data source too big?).

Related to: #301308
http://teampulse.telerik.com/view#item/301308